### PR TITLE
Update operator precedence for Agda 2.5.1

### DIFF
--- a/LambdaCalculus/BasicSystem/Syntax.agda
+++ b/LambdaCalculus/BasicSystem/Syntax.agda
@@ -1,5 +1,7 @@
 module BasicSystem.Syntax where
 
+infix 25 _[_]
+
 data Ty : Set where
   ι   : Ty
   _⇒_ : Ty -> Ty -> Ty

--- a/LambdaCalculus/BasicSystem/Utils.agda
+++ b/LambdaCalculus/BasicSystem/Utils.agda
@@ -1,6 +1,8 @@
 module BasicSystem.Utils where
 
 infix 10 _==_
+infix 15 _×_
+infix 15 _∧_∧_
 
 data Σ (A : Set) (B : A -> Set) : Set where
   sig : (a : A) -> B a -> Σ A B

--- a/LambdaCalculus/FiniteProducts/Syntax.agda
+++ b/LambdaCalculus/FiniteProducts/Syntax.agda
@@ -1,5 +1,7 @@
 module FiniteProducts.Syntax where
 
+infix 25 _[_]
+
 data Ty : Set where
   ι   : Ty  
   _⇒_ : Ty -> Ty -> Ty

--- a/LambdaCalculus/FiniteProducts/Utils.agda
+++ b/LambdaCalculus/FiniteProducts/Utils.agda
@@ -1,6 +1,8 @@
 module FiniteProducts.Utils where
 
 infix 10 _==_
+infix 15 _∧_
+infix 15 _∧_∧_
 
 data Σ (A : Set) (B : A -> Set) : Set where
   sig : (a : A) -> B a -> Σ A B

--- a/LambdaCalculus/NaturalNumbers/Syntax.agda
+++ b/LambdaCalculus/NaturalNumbers/Syntax.agda
@@ -1,5 +1,7 @@
 module NaturalNumbers.Syntax where
 
+infix 25 _[_]
+
 data Ty : Set where
   ι   : Ty
   _⇒_ : Ty -> Ty -> Ty

--- a/LambdaCalculus/NaturalNumbers/Utils.agda
+++ b/LambdaCalculus/NaturalNumbers/Utils.agda
@@ -1,6 +1,8 @@
 module NaturalNumbers.Utils where
 
 infix 10 _==_
+infix 15 _×_
+infix 15 _∧_∧_
 
 data Σ (A : Set) (B : A -> Set) : Set where
   sig : (a : A) -> B a -> Σ A B

--- a/LogicalFramework/BasicSystem/Syntax.agda
+++ b/LogicalFramework/BasicSystem/Syntax.agda
@@ -4,6 +4,10 @@ infix 10 _≡ˠ_
 infix 10 _≡⁺_
 infix 10 _≡ˢ_
 infix 10 _≡_
+infix 25 _[_]
+infix 25 _[_]'
+infix 25 _[_]⁺
+infix 25 _[_]⁺'
 infixl 50 _•_
 
 mutual 

--- a/LogicalFramework/BetaEta/Syntax.agda
+++ b/LogicalFramework/BetaEta/Syntax.agda
@@ -4,6 +4,10 @@ infix 10 _≡ˠ_
 infix 10 _≡⁺_
 infix 10 _≡ˢ_
 infix 10 _≡_
+infix 25 _[_]
+infix 25 _[_]'
+infix 25 _[_]⁺
+infix 25 _[_]⁺'
 infixl 50 _•_
 
 mutual 


### PR DESCRIPTION
Adding some precedences appears to be sufficient for all files to typecheck under the new parsing rules.
